### PR TITLE
Feature #8017: user calendars

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -579,7 +579,7 @@
       <dependency>
         <groupId>org.mnode.ical4j</groupId>
         <artifactId>ical4j</artifactId>
-        <version>1.0.6</version>
+        <version>2.0.0</version>
         <exclusions>
           <exclusion>
             <groupId>commons-logging</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -579,7 +579,7 @@
       <dependency>
         <groupId>org.mnode.ical4j</groupId>
         <artifactId>ical4j</artifactId>
-        <version>2.0.0</version>
+        <version>2.0.2</version>
         <exclusions>
           <exclusion>
             <groupId>org.slf4j</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -582,16 +582,20 @@
         <version>2.0.0</version>
         <exclusions>
           <exclusion>
-            <groupId>commons-logging</groupId>
-            <artifactId>commons-logging</artifactId>
+            <groupId>org.slf4j</groupId>
+            <artifactId>slf4j-api</artifactId>
           </exclusion>
           <exclusion>
             <groupId>commons-codec</groupId>
             <artifactId>commons-codec</artifactId>
           </exclusion>
           <exclusion>
-            <groupId>commons-lang</groupId>
-            <artifactId>commons-lang</artifactId>
+            <groupId>org.apache.commons</groupId>
+            <artifactId>commons-lang3</artifactId>
+          </exclusion>
+          <exclusion>
+            <groupId>biz.aQute.bnd</groupId>
+            <artifactId>bndlib</artifactId>
           </exclusion>
         </exclusions>
       </dependency>


### PR DESCRIPTION
WARNING: as some database tables already exist into current installed Silverpeas V6 (after first integration of the engine) and also because in an other side we wanted to keep version 001 for SQL scripts all database tables linked to the feature must be droped.
A good way to perform that is to get an installer released after the date of 27/04/2017 and put into config.properties file the parameter "DEV_CLEANUP_CALENDAR = true" before a clean install actions.
Don't forget to remove this parameter after a successful Silverpeas update!!!

Linked to PR:
* https://github.com/Silverpeas/Silverpeas-Core/pull/829
* https://github.com/Silverpeas/Silverpeas-Components/pull/548