### PR TITLE
Feature #12259

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -30,7 +30,7 @@
 
   <groupId>org.silverpeas</groupId>
   <artifactId>silverpeas-dependencies-bom</artifactId>
-  <version>1.5-SNAPSHOT</version>
+  <version>1.5-improve-it</version>
   <packaging>pom</packaging>
   <name>Silverpeas Dependencies BOM</name>
   <description>A BOM with all the dependencies required to build and run Silverpeas</description>

--- a/pom.xml
+++ b/pom.xml
@@ -30,7 +30,7 @@
 
   <groupId>org.silverpeas</groupId>
   <artifactId>silverpeas-dependencies-bom</artifactId>
-  <version>1.5-improve-it</version>
+  <version>1.5-SNAPSHOT</version>
   <packaging>pom</packaging>
   <name>Silverpeas Dependencies BOM</name>
   <description>A BOM with all the dependencies required to build and run Silverpeas</description>
@@ -643,7 +643,7 @@
       <dependency>
         <groupId>org.postgresql</groupId>
         <artifactId>postgresql</artifactId>
-        <version>42.2.14</version>
+        <version>42.2.19</version>
       </dependency>
       <dependency>
         <groupId>net.sourceforge.jtds</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -556,7 +556,7 @@
       <dependency>
         <groupId>org.mnode.ical4j</groupId>
         <artifactId>ical4j</artifactId>
-        <version>3.0.19</version>
+        <version>3.0.25</version>
         <exclusions>
           <exclusion>
             <groupId>com.sun.mail</groupId>


### PR DESCRIPTION
Refactor the way the integration tests are running: instead of starting a Wildfly instance for each test class, it is started before the execution of the whole integration tests of the project. So, Wildfly is set as a remote container for Arquillian.
This requires to set up differently Wildfly. Currently, Wildfly 23.0.0 has been prepared for that and a Docker image dedicated to such builds has been pushed into the hub: silverpeas/silverbuild:6.3-it.