### PR TITLE
Feature #13059

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -216,21 +216,21 @@
        transitive dependencies of Tika but we use explicitly some of them (like in the mail's
        attachments extractor or in the component Gallery) -->
       <dependency>
-        <groupId>org.tallison</groupId>
+        <groupId>com.drewnoakes</groupId>
         <artifactId>metadata-extractor</artifactId>
-        <version>2.15.0.1</version>
+        <version>2.18.0</version>
         <scope>provided</scope>
       </dependency>
       <dependency>
         <groupId>org.apache.pdfbox</groupId>
         <artifactId>pdfbox</artifactId>
-        <version>2.0.24</version>
+        <version>2.0.26</version>
         <scope>provided</scope>
       </dependency>
       <dependency>
         <groupId>org.apache.pdfbox</groupId>
         <artifactId>pdfbox-tools</artifactId>
-        <version>2.0.24</version>
+        <version>2.0.26</version>
         <scope>provided</scope>
       </dependency>
       <dependency>
@@ -260,7 +260,7 @@
       </dependency>
       <dependency>
         <groupId>org.apache.tika</groupId>
-        <artifactId>tika-parsers</artifactId>
+        <artifactId>tika-parsers-standard-package</artifactId>
         <version>${tika.version}</version>
         <scope>provided</scope>
       </dependency>
@@ -593,13 +593,6 @@
         <version>99.0-does-not-exist</version>
       </dependency>
 
-      <!-- Atom and RSS API -->
-      <dependency>
-        <groupId>com.rometools</groupId>
-        <artifactId>rome</artifactId>
-        <version>1.13.1</version>
-      </dependency>
-
       <!-- iCal API -->
       <dependency>
         <groupId>org.mnode.ical4j</groupId>
@@ -690,14 +683,21 @@
         <artifactId>jtds</artifactId>
         <version>1.3.1</version>
       </dependency>
-      <!-- the version should be the same than the one embedded in Wildfly -->
+      <!-- the version should be the same as the one embedded in Wildfly -->
       <dependency>
         <groupId>com.h2database</groupId>
         <artifactId>h2</artifactId>
-        <version>2.1.210</version>
+        <version>2.1.212</version>
       </dependency>
 
       <!-- Util dependencies -->
+      <!-- For nullity check -->
+      <dependency>
+        <groupId>com.google.code.findbugs</groupId>
+        <artifactId>jsr305</artifactId>
+        <version>3.0.2</version>
+        <scope>provided</scope> <!-- only usable at coding and build time -->
+      </dependency>
       <dependency>
         <groupId>commons-fileupload</groupId>
         <artifactId>commons-fileupload</artifactId>
@@ -709,23 +709,33 @@
           </exclusion>
         </exclusions>
       </dependency>
+      <!-- Provided by Jackrabbit JCA -->
+      <!-- Atom and RSS API -->
+      <dependency>
+        <groupId>com.rometools</groupId>
+        <artifactId>rome</artifactId>
+        <version>1.18.0</version>
+        <scope>provided</scope>
+      </dependency>
+      <!-- Provided by Jackrabbit JCA -->
       <dependency>
         <groupId>org.apache.commons</groupId>
         <artifactId>commons-collections4</artifactId>
         <version>4.4</version>
+        <scope>provided</scope>
       </dependency>
       <!-- Provided by Jackrabbit JCA -->
       <dependency>
         <groupId>commons-io</groupId>
         <artifactId>commons-io</artifactId>
-        <version>2.7</version>
+        <version>2.11.0</version>
         <scope>provided</scope>
       </dependency>
       <!-- Provided by Jackrabbit JCA -->
       <dependency>
         <groupId>commons-codec</groupId>
         <artifactId>commons-codec</artifactId>
-        <version>1.13</version>
+        <version>1.15</version>
         <scope>provided</scope>
       </dependency>
       <!-- Usually provided by Jackrabbit JCA, but it should be excluded so that we can use our
@@ -733,7 +743,7 @@
       <dependency>
         <groupId>org.apache.commons</groupId>
         <artifactId>commons-lang3</artifactId>
-        <version>3.10</version>
+        <version>3.12.0</version>
       </dependency>
       <dependency>
         <groupId>org.apache.commons</groupId>
@@ -759,13 +769,6 @@
         <groupId>org.apache.httpcomponents</groupId>
         <artifactId>httpclient</artifactId>
         <version>4.5.13</version>
-        <scope>provided</scope>
-      </dependency>
-      <!-- Provided by Jackrabbit JCA -->
-      <dependency>
-        <groupId>org.jetbrains</groupId>
-        <artifactId>annotations</artifactId>
-        <version>16.0.3</version>
         <scope>provided</scope>
       </dependency>
       <!-- Unicode and Globalization Support API -->
@@ -1123,12 +1126,12 @@
     <hibernate.version>5.4.24.Final</hibernate.version>
     <jackson-version>2.12.3</jackson-version>
     <lucene.version>7.1.0</lucene.version>
-    <!-- WARNING: the following dependencies version must be equal to the one on which depends
+    <!-- WARNING: the following dependencies' version must be equal to the one on which depends
          Silverpeas-Jackrabbit-JCA as they are provided by it -->
-    <tika.version>1.28.1</tika.version>
-    <bouncycastle.version>1.69</bouncycastle.version>
-    <poi.version>4.1.2</poi.version>
-    <jackrabbit.version>2.20.4</jackrabbit.version>
+    <tika.version>2.4.0</tika.version>
+    <bouncycastle.version>1.70</bouncycastle.version>
+    <poi.version>5.2.2</poi.version>
+    <jackrabbit.version>2.20.5</jackrabbit.version>
     <jcr.accesscontrol.version>1.4</jcr.accesscontrol.version>
   </properties>
 


### PR DESCRIPTION
Update dependencies according to the changes in the dependencies of the
Jackrabbit JCA project for security reasons.

Update versions of some dependencies.

Remove the dependency on Jetbrains annotations to prefer those provided
by the JSR 305; use the Google Findbugs implementation of the JSR 305.

Don't forget to merge also PR https://github.com/Silverpeas/silverpeas-test-dependencies-bom/pull/9