### PR TITLE
Feature #12866

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -517,7 +517,7 @@
       <dependency>
         <groupId>org.projectlombok</groupId>
         <artifactId>lombok</artifactId>
-        <version>1.18.12</version>
+        <version>1.18.26</version>
         <scope>runtime</scope>
       </dependency>
 
@@ -584,7 +584,7 @@
       <dependency>
         <groupId>org.ehcache</groupId>
         <artifactId>ehcache</artifactId>
-        <version>3.9.7</version>
+        <version>3.10.8</version>
         <exclusions>
           <exclusion>
             <groupId>org.glassfish.jaxb</groupId>
@@ -686,6 +686,10 @@
             <groupId>biz.aQute.bnd</groupId>
             <artifactId>bndlib</artifactId>
           </exclusion>
+          <exclusion>
+            <groupId>commons-validator</groupId>
+            <artifactId>commons-validator</artifactId>
+          </exclusion>
         </exclusions>
       </dependency>
 
@@ -747,7 +751,7 @@
       <dependency>
         <groupId>org.postgresql</groupId>
         <artifactId>postgresql</artifactId>
-        <version>42.3.7</version>
+        <version>42.5.3</version>
       </dependency>
       <dependency>
         <groupId>net.sourceforge.jtds</groupId>
@@ -758,7 +762,7 @@
       <dependency>
         <groupId>com.h2database</groupId>
         <artifactId>h2</artifactId>
-        <version>2.1.212</version>
+        <version>2.1.214</version>
       </dependency>
 
       <!-- Util dependencies -->
@@ -767,12 +771,11 @@
         <groupId>com.google.code.findbugs</groupId>
         <artifactId>jsr305</artifactId>
         <version>3.0.2</version>
-        <scope>provided</scope> <!-- only usable at coding and build time -->
       </dependency>
       <dependency>
         <groupId>commons-fileupload</groupId>
         <artifactId>commons-fileupload</artifactId>
-        <version>1.4</version>
+        <version>1.5</version>
         <exclusions>
           <exclusion>
             <groupId>commons-io</groupId>
@@ -784,6 +787,11 @@
         <groupId>org.apache.commons</groupId>
         <artifactId>commons-collections4</artifactId>
         <version>4.4</version>
+      </dependency>
+      <dependency>
+        <groupId>commons-validator</groupId>
+        <artifactId>commons-validator</artifactId>
+        <version>1.7</version>
       </dependency>
       <!-- Required by Oak -->
       <dependency>
@@ -806,7 +814,7 @@
       <dependency>
         <groupId>org.apache.commons</groupId>
         <artifactId>commons-text</artifactId>
-        <version>1.9</version>
+        <version>1.10.0</version>
       </dependency>
       <dependency>
         <groupId>org.apache.commons</groupId>
@@ -816,24 +824,24 @@
       <dependency>
         <groupId>org.apache.commons</groupId>
         <artifactId>commons-compress</artifactId>
-        <version>1.21</version>
+        <version>1.22</version>
       </dependency>
       <!-- Required by Jackrabbit WebDAV and by Google APIs -->
       <dependency>
         <groupId>org.apache.httpcomponents</groupId>
         <artifactId>httpclient</artifactId>
-        <version>4.5.13</version>
+        <version>4.5.14</version>
       </dependency>
       <dependency>
         <groupId>org.apache.httpcomponents</groupId>
         <artifactId>httpcore</artifactId>
-        <version>4.4.15</version>
+        <version>4.4.16</version>
       </dependency>
       <!-- Unicode and Globalization Support API -->
       <dependency>
         <groupId>com.ibm.icu</groupId>
         <artifactId>icu4j</artifactId>
-        <version>67.1</version>
+        <version>72.1</version>
       </dependency>
       <!-- Cryptolib TODO: replace it by JDK to handle X509 certificate  -->
       <dependency>
@@ -860,7 +868,7 @@
       <dependency>
         <groupId>com.thoughtworks.xstream</groupId>
         <artifactId>xstream</artifactId>
-        <version>1.4.19</version>
+        <version>1.4.20</version>
       </dependency>
       <!-- HTML Parsing API -->
       <dependency>
@@ -893,7 +901,7 @@
       <dependency>
         <groupId>com.itextpdf</groupId>
         <artifactId>itextpdf</artifactId>
-        <version>5.5.13.2</version>
+        <version>5.5.13.3</version>
         <exclusions>
           <exclusion>
             <groupId>bouncycastle</groupId>
@@ -1011,13 +1019,13 @@
       <dependency>
         <groupId>org.apache.cxf</groupId>
         <artifactId>cxf-rt-frontend-jaxws</artifactId>
-        <version>3.3.10</version>
+        <version>3.4.7</version>
         <scope>provided</scope>
       </dependency>
       <dependency>
         <groupId>org.apache.cxf</groupId>
         <artifactId>cxf-rt-transports-http</artifactId>
-        <version>3.3.10</version>
+        <version>3.4.7</version>
         <scope>provided</scope>
       </dependency>
 
@@ -1144,7 +1152,7 @@
       <dependency>
         <groupId>com.googlecode.owasp-java-html-sanitizer</groupId>
         <artifactId>owasp-java-html-sanitizer</artifactId>
-        <version>20211018.2</version>
+        <version>20220608.1</version>
         <exclusions>
           <exclusion>
             <groupId>com.google.guava</groupId>
@@ -1183,16 +1191,14 @@
     <owasp.version>1.2.3</owasp.version>
     <!-- WARNING: the following dependencies version must be equal to the one provided by Wildfly -->
     <slf4j.version>1.7.36</slf4j.version>
-    <log4j.version>2.17.2</log4j.version>
-    <resteasy.version>4.7.6.Final</resteasy.version>
-    <hibernate.version>5.3.24.Final</hibernate.version>
-    <jackson-version>2.12.6</jackson-version>
+    <log4j.version>2.19.0</log4j.version>
+    <resteasy.version>4.7.7.Final</resteasy.version>
+    <hibernate.version>5.3.28.Final</hibernate.version>
+    <jackson-version>2.12.7</jackson-version>
     <lucene.version>7.1.0</lucene.version>
-    <tika.version>2.4.0</tika.version>
+    <tika.version>2.6.0</tika.version>
     <bouncycastle.version>1.70</bouncycastle.version>
-    <poi.version>5.2.2</poi.version>
-    <!-- version of Netty to be used by Oak instead of its own dependencies on this framework -->
-    <netty.version>4.1.78.Final</netty.version>
+    <poi.version>5.2.3</poi.version>
   </properties>
 
 </project>

--- a/pom.xml
+++ b/pom.xml
@@ -522,10 +522,197 @@
       </dependency>
 
       <!-- JCR  -->
+      <!-- JCR API -->
       <dependency>
-        <groupId>org.silverpeas.jcr</groupId>
-        <artifactId>silverpeas-jcr</artifactId>
-        <version>1.0-SNAPSHOT</version>
+        <groupId>javax.jcr</groupId>
+        <artifactId>jcr</artifactId>
+        <version>2.0</version>
+        <scope>compile</scope>
+      </dependency>
+      <!-- Oak implementation of the JCR -->
+      <dependency>
+        <groupId>org.apache.jackrabbit</groupId>
+        <artifactId>oak-jcr</artifactId>
+        <version>${oak.version}</version>
+        <exclusions>
+          <exclusion>
+            <groupId>commons-io</groupId>
+            <artifactId>commons-io</artifactId>
+          </exclusion>
+          <exclusion>
+            <groupId>commons-codec</groupId>
+            <artifactId>commons-codec</artifactId>
+          </exclusion>
+          <exclusion>
+            <groupId>com.google.guava</groupId>
+            <artifactId>guava</artifactId>
+          </exclusion>
+          <exclusion>
+            <groupId>org.slf4j</groupId>
+            <artifactId>slf4j-api</artifactId>
+          </exclusion>
+          <exclusion>
+            <groupId>org.apache.sling</groupId>
+            <artifactId>org.apache.sling.testing.osgi-mock</artifactId>
+          </exclusion>
+        </exclusions>
+      </dependency>
+      <!-- Required by Oak -->
+      <dependency>
+        <groupId>commons-io</groupId>
+        <artifactId>commons-io</artifactId>
+        <version>2.11.0</version>
+      </dependency>
+      <dependency>
+        <groupId>commons-codec</groupId>
+        <artifactId>commons-codec</artifactId>
+        <version>1.15</version>
+      </dependency>
+      <!-- the filesystem storage backend for Oak -->
+      <dependency>
+        <groupId>org.apache.jackrabbit</groupId>
+        <artifactId>oak-segment-tar</artifactId>
+        <version>${oak.version}</version>
+        <exclusions>
+          <exclusion>
+            <groupId>com.google.guava</groupId>
+            <artifactId>guava</artifactId>
+          </exclusion>
+          <exclusion>
+            <groupId>commons-io</groupId>
+            <artifactId>commons-io</artifactId>
+          </exclusion>
+          <exclusion>
+            <groupId>io.netty</groupId>
+            <artifactId>netty-buffer</artifactId>
+          </exclusion>
+          <exclusion>
+            <groupId>io.netty</groupId>
+            <artifactId>netty-codec</artifactId>
+          </exclusion>
+          <exclusion>
+            <groupId>io.netty</groupId>
+            <artifactId>netty-common</artifactId>
+          </exclusion>
+          <exclusion>
+            <groupId>io.netty</groupId>
+            <artifactId>netty-handler</artifactId>
+          </exclusion>
+          <exclusion>
+            <groupId>io.netty</groupId>
+            <artifactId>netty-resolver</artifactId>
+          </exclusion>
+          <exclusion>
+            <groupId>io.netty</groupId>
+            <artifactId>netty-transport</artifactId>
+          </exclusion>
+        </exclusions>
+      </dependency>
+      <dependency>
+        <groupId>io.dropwizard.metrics</groupId>
+        <artifactId>metrics-core</artifactId>
+        <version>3.2.6</version>
+      </dependency>
+      <!-- the document-based datasource storage backend for Oak -->
+      <dependency>
+        <groupId>org.apache.jackrabbit</groupId>
+        <artifactId>oak-store-document</artifactId>
+        <version>${oak.version}</version>
+        <exclusions>
+          <exclusion>
+            <groupId>com.google.guava</groupId>
+            <artifactId>guava</artifactId>
+          </exclusion>
+          <exclusion>
+            <groupId>com.h2database</groupId>
+            <artifactId>h2</artifactId>
+          </exclusion>
+          <exclusion>
+            <groupId>commons-io</groupId>
+            <artifactId>commons-io</artifactId>
+          </exclusion>
+          <exclusion>
+            <groupId>commons-codec</groupId>
+            <artifactId>commons-codec</artifactId>
+          </exclusion>
+          <exclusion>
+            <groupId>org.slf4j</groupId>
+            <artifactId>slf4j-api</artifactId>
+          </exclusion>
+        </exclusions>
+      </dependency>
+      <!-- MongoDB to be used as a document-base datasource for Oak -->
+      <dependency>
+        <groupId>org.mongodb</groupId>
+        <artifactId>mongo-java-driver</artifactId>
+        <version>${mongo.driver.version}</version>
+      </dependency>
+      <!-- Netty required by Oak (an asynchronous event-driven network application framework) -->
+      <dependency>
+        <groupId>io.netty</groupId>
+        <artifactId>netty-buffer</artifactId>
+        <version>${netty.version}</version>
+      </dependency>
+      <dependency>
+        <groupId>io.netty</groupId>
+        <artifactId>netty-codec</artifactId>
+        <version>${netty.version}</version>
+      </dependency>
+      <dependency>
+        <groupId>io.netty</groupId>
+        <artifactId>netty-common</artifactId>
+        <version>${netty.version}</version>
+      </dependency>
+      <dependency>
+        <groupId>io.netty</groupId>
+        <artifactId>netty-handler</artifactId>
+        <version>${netty.version}</version>
+      </dependency>
+      <dependency>
+        <groupId>io.netty</groupId>
+        <artifactId>netty-resolver</artifactId>
+        <version>${netty.version}</version>
+      </dependency>
+      <dependency>
+        <groupId>io.netty</groupId>
+        <artifactId>netty-transport</artifactId>
+        <version>${netty.version}</version>
+      </dependency>
+      <!-- Jackrabbit WebDAV facilities to access JCR through WebDAV -->
+      <dependency>
+        <groupId>org.apache.jackrabbit</groupId>
+        <artifactId>jackrabbit-jcr-server</artifactId>
+        <version>${jackrabbit.version}</version>
+        <exclusions>
+          <exclusion>
+            <groupId>commons-fileupload</groupId>
+            <artifactId>commons-fileupload</artifactId>
+          </exclusion>
+          <exclusion>
+            <groupId>org.apache.tika</groupId>
+            <artifactId>tika-core</artifactId>
+          </exclusion>
+          <exclusion>
+            <groupId>commons-collections</groupId>
+            <artifactId>commons-collections</artifactId>
+          </exclusion>
+          <exclusion>
+            <groupId>org.apache.httpcomponents</groupId>
+            <artifactId>httpclient</artifactId>
+          </exclusion>
+          <exclusion>
+            <groupId>org.apache.httpcomponents</groupId>
+            <artifactId>httpcore</artifactId>
+          </exclusion>
+          <exclusion>
+            <groupId>org.slf4j</groupId>
+            <artifactId>slf4j-api</artifactId>
+          </exclusion>
+          <exclusion>
+            <groupId>org.slf4j</groupId>
+            <artifactId>jcl-over-slf4j</artifactId>
+          </exclusion>
+        </exclusions>
       </dependency>
 
       <!-- The Bouncy Castle dependencies. Provided by Tika -->
@@ -792,17 +979,6 @@
         <groupId>commons-validator</groupId>
         <artifactId>commons-validator</artifactId>
         <version>1.7</version>
-      </dependency>
-      <!-- Required by Oak -->
-      <dependency>
-        <groupId>commons-io</groupId>
-        <artifactId>commons-io</artifactId>
-        <version>2.11.0</version>
-      </dependency>
-      <dependency>
-        <groupId>commons-codec</groupId>
-        <artifactId>commons-codec</artifactId>
-        <version>1.15</version>
       </dependency>
       <!-- Usually provided by Tika, but it should be excluded so that we can use our
            own dependency (for classloading issues as SerializationUtils is used by us) -->
@@ -1199,6 +1375,12 @@
     <tika.version>2.6.0</tika.version>
     <bouncycastle.version>1.70</bouncycastle.version>
     <poi.version>5.2.3</poi.version>
+    <oak.version>1.48.0</oak.version>
+    <!-- version of Netty to be used by Oak instead of its own dependencies on this framework -->
+    <netty.version>4.1.87.Final</netty.version>
+    <!-- version of JackRabbit for the WebDAV support -->
+    <jackrabbit.version>2.20.8</jackrabbit.version>
+    <mongo.driver.version>3.12.11</mongo.driver.version>
   </properties>
 
 </project>

--- a/pom.xml
+++ b/pom.xml
@@ -212,57 +212,145 @@
         <artifactId>jericho-html</artifactId>
         <version>3.4</version>
       </dependency>
-      <!-- The following content parsing dependencies are all provided by Jackrabbit JCA. They are
-       transitive dependencies of Tika but we use explicitly some of them (like in the mail's
-       attachments extractor or in the component Gallery) -->
+
+      <!-- The following content parsing dependencies are all provided by Tika, but we use explicitly
+       some of them (like in the mail's attachments extractor or in the component Gallery) so we
+       explicitly declare them to control any possible change -->
       <dependency>
         <groupId>com.drewnoakes</groupId>
         <artifactId>metadata-extractor</artifactId>
         <version>2.18.0</version>
-        <scope>provided</scope>
       </dependency>
       <dependency>
         <groupId>org.apache.pdfbox</groupId>
         <artifactId>pdfbox</artifactId>
         <version>2.0.26</version>
-        <scope>provided</scope>
       </dependency>
       <dependency>
         <groupId>org.apache.pdfbox</groupId>
         <artifactId>pdfbox-tools</artifactId>
         <version>2.0.26</version>
-        <scope>provided</scope>
       </dependency>
       <dependency>
         <groupId>org.apache.poi</groupId>
         <artifactId>poi</artifactId>
         <version>${poi.version}</version>
-        <scope>provided</scope>
       </dependency>
       <dependency>
         <groupId>org.apache.poi</groupId>
         <artifactId>poi-scratchpad</artifactId>
         <version>${poi.version}</version>
-        <scope>provided</scope>
       </dependency>
       <dependency>
         <groupId>org.apache.poi</groupId>
         <artifactId>poi-ooxml</artifactId>
         <version>${poi.version}</version>
-        <scope>provided</scope>
       </dependency>
       <!-- Tika dependencies -->
       <dependency>
         <groupId>org.apache.tika</groupId>
         <artifactId>tika-core</artifactId>
         <version>${tika.version}</version>
-        <scope>provided</scope>
       </dependency>
       <dependency>
         <groupId>org.apache.tika</groupId>
         <artifactId>tika-parsers-standard-package</artifactId>
         <version>${tika.version}</version>
-        <scope>provided</scope>
+        <!-- we exclude all for which Silverpeas depends on them explicitly -->
+        <exclusions>
+          <exclusion>
+            <groupId>org.apache.tika</groupId>
+            <artifactId>tika-core</artifactId>
+          </exclusion>
+          <exclusion>
+            <groupId>org.apache.pdfbox</groupId>
+            <artifactId>pdfbox</artifactId>
+          </exclusion>
+          <exclusion>
+            <groupId>org.apache.pdfbox</groupId>
+            <artifactId>pdfbox-tools</artifactId>
+          </exclusion>
+          <exclusion>
+            <groupId>org.apache.poi</groupId>
+            <artifactId>poi</artifactId>
+          </exclusion>
+          <exclusion>
+            <groupId>org.apache.poi</groupId>
+            <artifactId>poi-scratchpad</artifactId>
+          </exclusion>
+          <exclusion>
+            <groupId>org.apache.poi</groupId>
+            <artifactId>poi-ooxml</artifactId>
+          </exclusion>
+          <exclusion>
+            <groupId>de.l3s.boilerpipe</groupId>
+            <artifactId>boilerpipe</artifactId>
+          </exclusion>
+          <exclusion>
+            <groupId>com.drewnoakes</groupId>
+            <artifactId>metadata-extractor</artifactId>
+          </exclusion>
+          <exclusion>
+            <groupId>org.apache.commons</groupId>
+            <artifactId>commons-collections4</artifactId>
+          </exclusion>
+          <exclusion>
+            <groupId>org.apache.commons</groupId>
+            <artifactId>commons-lang3</artifactId>
+          </exclusion>
+          <exclusion>
+            <groupId>org.apache.commons</groupId>
+            <artifactId>commons-compress</artifactId>
+          </exclusion>
+          <exclusion>
+            <groupId>org.apache.commons</groupId>
+            <artifactId>commons-codec</artifactId>
+          </exclusion>
+          <exclusion>
+            <groupId>org.apache.commons</groupId>
+            <artifactId>commons-exec</artifactId>
+          </exclusion>
+          <exclusion>
+            <groupId>commons-io</groupId>
+            <artifactId>commons-io</artifactId>
+          </exclusion>
+          <exclusion>
+            <groupId>com.rometools</groupId>
+            <artifactId>rome</artifactId>
+          </exclusion>
+          <exclusion>
+            <groupId>org.bouncycastle</groupId>
+            <artifactId>bcmail-jdk15on</artifactId>
+          </exclusion>
+          <exclusion>
+            <groupId>org.bouncycastle</groupId>
+            <artifactId>bcprov-jdk15on</artifactId>
+          </exclusion>
+          <exclusion>
+            <groupId>xerces</groupId>
+            <artifactId>xercesImpl</artifactId>
+          </exclusion>
+          <exclusion>
+            <groupId>org.glassfish.jaxb</groupId>
+            <artifactId>jaxb-runtime</artifactId>
+          </exclusion>
+          <exclusion>
+            <groupId>commons-logging</groupId>
+            <artifactId>commons-logging</artifactId>
+          </exclusion>
+          <exclusion>
+            <groupId>org.slf4j</groupId>
+            <artifactId>slf4j-api</artifactId>
+          </exclusion>
+          <exclusion>
+            <groupId>org.slf4j</groupId>
+            <artifactId>jul-to-slf4j </artifactId>
+          </exclusion>
+          <exclusion>
+            <groupId>org.slf4j</groupId>
+            <artifactId>jcl-over-slf4j</artifactId>
+          </exclusion>
+        </exclusions>
       </dependency>
 
       <!-- Spring Social dependencies -->
@@ -272,15 +360,15 @@
         <version>1.0.2.RELEASE</version>
         <exclusions>
           <exclusion>
-            <groupId>com.fasterxml.jackson.core </groupId>
+            <groupId>com.fasterxml.jackson.core</groupId>
             <artifactId>jackson-core</artifactId>
           </exclusion>
           <exclusion>
-            <groupId>com.fasterxml.jackson.core </groupId>
+            <groupId>com.fasterxml.jackson.core</groupId>
             <artifactId>jackson-databind</artifactId>
           </exclusion>
           <exclusion>
-            <groupId>com.fasterxml.jackson.core </groupId>
+            <groupId>com.fasterxml.jackson.core</groupId>
             <artifactId>jackson-annotations</artifactId>
           </exclusion>
           <exclusion>
@@ -299,15 +387,15 @@
         <version>2.0.3.RELEASE</version>
         <exclusions>
           <exclusion>
-            <groupId>com.fasterxml.jackson.core </groupId>
+            <groupId>com.fasterxml.jackson.core</groupId>
             <artifactId>jackson-core</artifactId>
           </exclusion>
           <exclusion>
-            <groupId>com.fasterxml.jackson.core </groupId>
+            <groupId>com.fasterxml.jackson.core</groupId>
             <artifactId>jackson-databind</artifactId>
           </exclusion>
           <exclusion>
-            <groupId>com.fasterxml.jackson.core </groupId>
+            <groupId>com.fasterxml.jackson.core</groupId>
             <artifactId>jackson-annotations</artifactId>
           </exclusion>
           <exclusion>
@@ -433,50 +521,25 @@
         <scope>runtime</scope>
       </dependency>
 
-      <!-- JCR dependencies. Provided by Jackrabbit JCA -->
-      <dependency>
-        <groupId>javax.jcr</groupId>
-        <artifactId>jcr</artifactId>
-        <version>2.0</version>
-        <scope>provided</scope>
-      </dependency>
+      <!-- JCR  -->
       <dependency>
         <groupId>org.silverpeas.jcr</groupId>
-        <artifactId>access-control</artifactId>
-        <version>${jcr.accesscontrol.version}</version>
-        <scope>provided</scope>
-      </dependency>
-      <dependency>
-        <groupId>org.apache.jackrabbit</groupId>
-        <artifactId>jackrabbit-core</artifactId>
-        <version>${jackrabbit.version}</version>
-        <scope>provided</scope>
-      </dependency>
-      <dependency>
-        <groupId>org.apache.jackrabbit</groupId>
-        <artifactId>jackrabbit-jcr-server</artifactId>
-        <version>${jackrabbit.version}</version>
-        <scope>provided</scope>
-      </dependency>
-      <dependency>
-        <groupId>org.apache.jackrabbit</groupId>
-        <artifactId>jackrabbit-webdav</artifactId>
-        <version>${jackrabbit.version}</version>
-        <scope>provided</scope>
+        <artifactId>silverpeas-jcr</artifactId>
+        <version>1.0-SNAPSHOT</version>
       </dependency>
 
-      <!-- The Bouncy Castle dependencies. Provided by Jackrabbit JCA through Tika -->
+      <!-- The Bouncy Castle dependencies. Provided by Tika -->
       <dependency>
         <groupId>org.bouncycastle</groupId>
         <artifactId>bcprov-jdk15on</artifactId>
         <version>${bouncycastle.version}</version>
-        <scope>provided</scope>
+        <scope>compile</scope>
       </dependency>
       <dependency>
         <groupId>org.bouncycastle</groupId>
         <artifactId>bcmail-jdk15on</artifactId>
         <version>${bouncycastle.version}</version>
-        <scope>provided</scope>
+        <scope>compile</scope>
       </dependency>
 
       <!-- Authentication mechanisms -->
@@ -644,6 +707,14 @@
         </exclusions>
       </dependency>
 
+      <!-- Atom and RSS API -->
+      <dependency>
+        <groupId>com.rometools</groupId>
+        <artifactId>rome</artifactId>
+        <version>1.18.0</version>
+        <scope>compile</scope>
+      </dependency>
+
       <!-- ImageMagick API -->
       <dependency>
         <groupId>org.im4java</groupId>
@@ -657,7 +728,7 @@
         <artifactId>stringtemplate</artifactId>
         <version>3.2.1</version>
         <exclusions>
-           <!-- antlr is provided by Wildfly -->
+          <!-- antlr is provided by Wildfly -->
           <exclusion>
             <groupId>antlr</groupId>
             <artifactId>antlr</artifactId>
@@ -709,36 +780,23 @@
           </exclusion>
         </exclusions>
       </dependency>
-      <!-- Provided by Jackrabbit JCA -->
-      <!-- Atom and RSS API -->
-      <dependency>
-        <groupId>com.rometools</groupId>
-        <artifactId>rome</artifactId>
-        <version>1.18.0</version>
-        <scope>provided</scope>
-      </dependency>
-      <!-- Provided by Jackrabbit JCA -->
       <dependency>
         <groupId>org.apache.commons</groupId>
         <artifactId>commons-collections4</artifactId>
         <version>4.4</version>
-        <scope>provided</scope>
       </dependency>
-      <!-- Provided by Jackrabbit JCA -->
+      <!-- Required by Oak -->
       <dependency>
         <groupId>commons-io</groupId>
         <artifactId>commons-io</artifactId>
         <version>2.11.0</version>
-        <scope>provided</scope>
       </dependency>
-      <!-- Provided by Jackrabbit JCA -->
       <dependency>
         <groupId>commons-codec</groupId>
         <artifactId>commons-codec</artifactId>
         <version>1.15</version>
-        <scope>provided</scope>
       </dependency>
-      <!-- Usually provided by Jackrabbit JCA, but it should be excluded so that we can use our
+      <!-- Usually provided by Tika, but it should be excluded so that we can use our
            own dependency (for classloading issues as SerializationUtils is used by us) -->
       <dependency>
         <groupId>org.apache.commons</groupId>
@@ -748,28 +806,28 @@
       <dependency>
         <groupId>org.apache.commons</groupId>
         <artifactId>commons-text</artifactId>
-        <version>1.8</version>
+        <version>1.9</version>
       </dependency>
-      <!-- Provided by Jackrabbit JCA -->
       <dependency>
         <groupId>org.apache.commons</groupId>
         <artifactId>commons-exec</artifactId>
         <version>1.3</version>
-        <scope>provided</scope>
       </dependency>
-      <!-- Provided by Jackrabbit JCA -->
       <dependency>
         <groupId>org.apache.commons</groupId>
         <artifactId>commons-compress</artifactId>
         <version>1.21</version>
-        <scope>provided</scope>
       </dependency>
-      <!-- Provided by Jackrabbit JCA -->
+      <!-- Required by Jackrabbit WebDAV and by Google APIs -->
       <dependency>
         <groupId>org.apache.httpcomponents</groupId>
         <artifactId>httpclient</artifactId>
         <version>4.5.13</version>
-        <scope>provided</scope>
+      </dependency>
+      <dependency>
+        <groupId>org.apache.httpcomponents</groupId>
+        <artifactId>httpcore</artifactId>
+        <version>4.4.15</version>
       </dependency>
       <!-- Unicode and Globalization Support API -->
       <dependency>
@@ -1130,13 +1188,11 @@
     <hibernate.version>5.3.24.Final</hibernate.version>
     <jackson-version>2.12.6</jackson-version>
     <lucene.version>7.1.0</lucene.version>
-    <!-- WARNING: the following dependencies' version must be equal to the one on which depends
-         Silverpeas-Jackrabbit-JCA as they are provided by it -->
     <tika.version>2.4.0</tika.version>
     <bouncycastle.version>1.70</bouncycastle.version>
     <poi.version>5.2.2</poi.version>
-    <jackrabbit.version>2.20.5</jackrabbit.version>
-    <jcr.accesscontrol.version>1.4</jcr.accesscontrol.version>
+    <!-- version of Netty to be used by Oak instead of its own dependencies on this framework -->
+    <netty.version>4.1.78.Final</netty.version>
   </properties>
 
 </project>


### PR DESCRIPTION
In the replacement of Jackrabbit by Oak, the access to the JCR repository is now done by a lib instead of a JCA. So dependencies requires to be managed differently.

The following PRs require to be merged along with this one:
- https://github.com/Silverpeas/silverpeas-test-dependencies-bom/pull/10
- https://github.com/Silverpeas/Silverpeas-Project/pull/8

The following PRs require to be integrated afeter this one:
- https://github.com/Silverpeas/Silverpeas-Core/pull/1255
- https://github.com/Silverpeas/Silverpeas-Components/pull/809
- https://github.com/Silverpeas/Silverpeas-Assembly/pull/24